### PR TITLE
Feat: Add JWT validation against customer endpoints

### DIFF
--- a/database/create_tables.sql
+++ b/database/create_tables.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS config(
     config_id BIGSERIAL PRIMARY KEY,
     app_id TEXT NOT NULL UNIQUE,
     jwks_endpoint TEXT,
-    verify_claims TEXT,
+    verify_subject BOOLEAN DEFAULT FALSE,
     created_utc TIMESTAMP WITH TIME ZONE NOT NULL,
     modified_utc TIMESTAMP WITH TIME ZONE NOT NULL
 );
@@ -44,4 +44,15 @@ CREATE TABLE IF NOT EXISTS address(
     created_utc TIMESTAMP WITH TIME ZONE NOT NULL,
     FOREIGN KEY(cid_id) REFERENCES cid(cid_id),
     UNIQUE(cid_id, address)
+);
+
+-- -----------------------------------------------------------------------
+-- JWKS
+-- -----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS jwks(
+    jwks_id BIGSERIAL PRIMARY KEY,
+    endpoint TEXT NOT NULL UNIQUE,
+    key_set TEXT NOT NULL,
+    modified_utc TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_utc TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/src/main/java/com/mytiki/l0_registry/features/FeaturesConfig.java
+++ b/src/main/java/com/mytiki/l0_registry/features/FeaturesConfig.java
@@ -8,6 +8,7 @@ package com.mytiki.l0_registry.features;
 import com.mytiki.l0_registry.features.latest.address.AddressConfig;
 import com.mytiki.l0_registry.features.latest.config.ConfigConfig;
 import com.mytiki.l0_registry.features.latest.id.IdConfig;
+import com.mytiki.l0_registry.features.latest.jwks.JwksConfig;
 import com.mytiki.l0_registry.features.latest.sign.SignConfig;
 import org.springframework.context.annotation.Import;
 
@@ -15,6 +16,7 @@ import org.springframework.context.annotation.Import;
         ConfigConfig.class,
         IdConfig.class,
         AddressConfig.class,
-        SignConfig.class
+        SignConfig.class,
+        JwksConfig.class
 })
 public class FeaturesConfig {}

--- a/src/main/java/com/mytiki/l0_registry/features/latest/address/AddressConfig.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/address/AddressConfig.java
@@ -7,6 +7,7 @@ package com.mytiki.l0_registry.features.latest.address;
 
 
 import com.mytiki.l0_registry.utilities.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -17,7 +18,7 @@ public class AddressConfig {
     public static final String PACKAGE_PATH = Constants.PACKAGE_FEATURES_LATEST_DOT_PATH + ".address";
 
     @Bean
-    public AddressService addressService(AddressRepository repository){
+    public AddressService addressService(@Autowired AddressRepository repository){
         return new AddressService(repository);
     }
 }

--- a/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigAOReq.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigAOReq.java
@@ -15,15 +15,15 @@ import java.util.List;
 public class ConfigAOReq {
     private String appId;
     private URI jwksEndpoint;
-    private List<String> claims;
+    private Boolean verifySubject;
 
     @JsonCreator
     public ConfigAOReq(@JsonProperty(required = true) String appId,
                        @JsonProperty URI jwksEndpoint,
-                       @JsonProperty List<String> claims) {
+                       @JsonProperty Boolean verifySubject) {
         this.appId = appId;
         this.jwksEndpoint = jwksEndpoint;
-        this.claims = claims;
+        this.verifySubject = verifySubject;
     }
 
     public String getAppId() {
@@ -42,11 +42,11 @@ public class ConfigAOReq {
         this.jwksEndpoint = jwksEndpoint;
     }
 
-    public List<String> getClaims() {
-        return claims;
+    public Boolean getVerifySubject() {
+        return verifySubject;
     }
 
-    public void setClaims(List<String> claims) {
-        this.claims = claims;
+    public void setVerifySubject(Boolean verifySubject) {
+        this.verifySubject = verifySubject;
     }
 }

--- a/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigAORsp.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigAORsp.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class ConfigAORsp {
     private String appId;
     private URI jwksEndpoint;
-    private List<String> claims;
+    private Boolean verifySubject;
     private ZonedDateTime created;
     private ZonedDateTime modified;
 
@@ -32,12 +32,12 @@ public class ConfigAORsp {
         this.jwksEndpoint = jwksEndpoint;
     }
 
-    public List<String> getClaims() {
-        return claims;
+    public Boolean getVerifySubject() {
+        return verifySubject;
     }
 
-    public void setClaims(List<String> claims) {
-        this.claims = claims;
+    public void setVerifySubject(Boolean verifySubject) {
+        this.verifySubject = verifySubject;
     }
 
     public ZonedDateTime getCreated() {

--- a/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigConfig.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigConfig.java
@@ -7,6 +7,7 @@ package com.mytiki.l0_registry.features.latest.config;
 
 
 import com.mytiki.l0_registry.utilities.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -17,12 +18,12 @@ public class ConfigConfig {
     public static final String PACKAGE_PATH = Constants.PACKAGE_FEATURES_LATEST_DOT_PATH + ".config";
 
     @Bean
-    public ConfigController configController(ConfigService service){
+    public ConfigController configController(@Autowired ConfigService service){
         return new ConfigController(service);
     }
 
     @Bean
-    public ConfigService configService(ConfigRepository repository){
+    public ConfigService configService(@Autowired ConfigRepository repository){
         return new ConfigService(repository);
     }
 }

--- a/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigDO.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigDO.java
@@ -18,7 +18,7 @@ public class ConfigDO implements Serializable {
     private Long configId;
     private String appId;
     private String jwksEndpoint;
-    private String claims;
+    private boolean verifySubject;
     private ZonedDateTime created;
     private ZonedDateTime modified;
 
@@ -42,7 +42,7 @@ public class ConfigDO implements Serializable {
         this.appId = appId;
     }
 
-    @Column(name = "jwksEndpoint")
+    @Column(name = "jwks_endpoint")
     public String getJwksEndpoint() {
         return jwksEndpoint;
     }
@@ -51,13 +51,13 @@ public class ConfigDO implements Serializable {
         this.jwksEndpoint = jwksEndpoint;
     }
 
-    @Column(name = "verify_claims")
-    public String getClaims() {
-        return claims;
+    @Column(name = "verify_subject")
+    public boolean getVerifySubject() {
+        return verifySubject;
     }
 
-    public void setClaims(String claims) {
-        this.claims = claims;
+    public void setVerifySubject(boolean verifySubject) {
+        this.verifySubject = verifySubject;
     }
 
     @Column(name = "created_utc")

--- a/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigService.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/config/ConfigService.java
@@ -38,8 +38,8 @@ public class ConfigService {
         }
         if(req.getJwksEndpoint() != null)
             save.setJwksEndpoint(req.getJwksEndpoint().toString());
-        if(req.getClaims() != null)
-            save.setClaims(String.join(",", req.getClaims()));
+        if(req.getVerifySubject() != null)
+            save.setVerifySubject(req.getVerifySubject());
         save.setModified(now);
         return toRsp(repository.save(save));
     }
@@ -73,8 +73,7 @@ public class ConfigService {
                         .build();
             }
         }
-        if(cfg.getClaims() != null)
-            rsp.setClaims(List.of(cfg.getClaims().split(",")));
+        rsp.setVerifySubject(cfg.getVerifySubject());
         return rsp;
     }
 }

--- a/src/main/java/com/mytiki/l0_registry/features/latest/id/IdConfig.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/id/IdConfig.java
@@ -8,8 +8,10 @@ package com.mytiki.l0_registry.features.latest.id;
 
 import com.mytiki.l0_registry.features.latest.address.AddressService;
 import com.mytiki.l0_registry.features.latest.config.ConfigService;
+import com.mytiki.l0_registry.features.latest.jwks.JwksService;
 import com.mytiki.l0_registry.features.latest.sign.SignService;
 import com.mytiki.l0_registry.utilities.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -20,16 +22,17 @@ public class IdConfig {
     public static final String PACKAGE_PATH = Constants.PACKAGE_FEATURES_LATEST_DOT_PATH + ".id";
 
     @Bean
-    public IdController idController(IdService service){
+    public IdController idController(@Autowired IdService service){
         return new IdController(service);
     }
 
     @Bean
     public IdService idService(
-            IdRepository repository,
-            ConfigService configService,
-            SignService signService,
-            AddressService addressService){
-        return new IdService(repository, configService, signService, addressService);
+            @Autowired IdRepository repository,
+            @Autowired ConfigService configService,
+            @Autowired SignService signService,
+            @Autowired AddressService addressService,
+            @Autowired JwksService jwksService){
+        return new IdService(repository, configService, signService, addressService, jwksService);
     }
 }

--- a/src/main/java/com/mytiki/l0_registry/features/latest/id/IdController.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/id/IdController.java
@@ -34,8 +34,13 @@ public class IdController {
     @RequestMapping(method = RequestMethod.POST)
     public IdAORsp postId(Principal principal,
                           @RequestHeader(AddressSignature.HEADER) String addressSignature,
+                          @RequestHeader(value = "X-Customer-Authorization", required = false) String customerToken,
                           @RequestBody IdAOReq body) {
-        return service.register(principal.getName(), body, new AddressSignature(addressSignature));
+        return service.register(
+                principal.getName(),
+                body,
+                new AddressSignature(addressSignature),
+                customerToken.replace("Bearer: ", ""));
     }
 
     @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-id-get",
@@ -45,7 +50,12 @@ public class IdController {
     public IdAORsp postAddresses(
             Principal principal,
             @RequestHeader(AddressSignature.HEADER) String addressSignature,
+            @RequestHeader(value = "X-Customer-Authorization", required = false) String customerToken,
             @PathVariable("id") String id) {
-        return service.get(principal.getName(), id, new AddressSignature(addressSignature));
+        return service.get(
+                principal.getName(),
+                id,
+                new AddressSignature(addressSignature),
+                customerToken.replace("Bearer: ", ""));
     }
 }

--- a/src/main/java/com/mytiki/l0_registry/features/latest/jwks/JwksConfig.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/jwks/JwksConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_registry.features.latest.jwks;
+
+import com.mytiki.l0_registry.features.latest.config.ConfigConfig;
+import com.mytiki.l0_registry.features.latest.config.ConfigService;
+import com.mytiki.l0_registry.utilities.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@EnableJpaRepositories(JwksConfig.PACKAGE_PATH)
+@EntityScan(JwksConfig.PACKAGE_PATH)
+public class JwksConfig {
+    public static final String PACKAGE_PATH = Constants.PACKAGE_FEATURES_LATEST_DOT_PATH + ".jwks";
+
+    @Bean
+    public JwksService jwksService(
+            @Autowired JwksRepository repository,
+            @Autowired RestTemplateBuilder restTemplateBuilder){
+        return new JwksService(repository, restTemplateBuilder.build(), 3600);
+    }
+}

--- a/src/main/java/com/mytiki/l0_registry/features/latest/jwks/JwksDO.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/jwks/JwksDO.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_registry.features.latest.jwks;
+
+import jakarta.persistence.*;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "jwks")
+public class JwksDO implements Serializable {
+
+    private Long jwksId;
+    private String endpoint;
+    private String keySet;
+    private ZonedDateTime modified;
+    private ZonedDateTime created;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "jwks_id")
+    public Long getJwksId() {
+        return jwksId;
+    }
+
+    public void setJwksId(Long jwksId) {
+        this.jwksId = jwksId;
+    }
+
+    @Column(name = "endpoint")
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    @Column(name = "key_set")
+    public String getKeySet() {
+        return keySet;
+    }
+
+    public void setKeySet(String keySet) {
+        this.keySet = keySet;
+    }
+
+    @Column(name = "modified_utc")
+    public ZonedDateTime getModified() {
+        return modified;
+    }
+
+    public void setModified(ZonedDateTime modified) {
+        this.modified = modified;
+    }
+
+    @Column(name = "created_utc")
+    public ZonedDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(ZonedDateTime created) {
+        this.created = created;
+    }
+}

--- a/src/main/java/com/mytiki/l0_registry/features/latest/jwks/JwksRepository.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/jwks/JwksRepository.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_registry.features.latest.jwks;
+
+import com.mytiki.l0_registry.features.latest.config.ConfigDO;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JwksRepository extends JpaRepository<JwksDO, Long> {
+    Optional<JwksDO> getByEndpoint(String endpoint);
+}

--- a/src/main/java/com/mytiki/l0_registry/features/latest/jwks/JwksService.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/jwks/JwksService.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_registry.features.latest.jwks;
+
+import com.mytiki.l0_registry.features.latest.config.ConfigDO;
+import com.mytiki.l0_registry.features.latest.config.ConfigService;
+import com.mytiki.spring_rest_api.ApiExceptionBuilder;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.*;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class JwksService {
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private final int cacheSeconds;
+    private final JwksRepository repository;
+    private final RestTemplate client;
+
+    public JwksService(JwksRepository repository, RestTemplate client, int cacheSeconds) {
+        this.repository = repository;
+        this.client = client;
+        this.cacheSeconds = cacheSeconds;
+    }
+
+    public void guard(String id, String token, ConfigDO config){
+        if(config.getJwksEndpoint() == null) return;
+        try {
+            JWKSet jwks = get(config.getJwksEndpoint());
+            if (jwks != null) {
+                JwtDecoder decoder = buildDecoder(jwks);
+                Jwt jwt = decoder.decode(token);
+                if(config.getVerifySubject() && !jwt.getSubject().equals(id)){
+                    throw new ApiExceptionBuilder(HttpStatus.UNAUTHORIZED)
+                            .message("Invalid sub claim")
+                            .build();
+                }
+            }
+        } catch (URISyntaxException | ParseException e) {
+            logger.error("Failed to fetch endpoint, skipping.", e);
+        } catch (JwtException e){
+            throw new ApiExceptionBuilder(HttpStatus.UNAUTHORIZED)
+                    .message("Invalid token")
+                    .build();
+        }
+    }
+
+    private JWKSet get(String endpoint) throws URISyntaxException, ParseException {
+        Optional<JwksDO> saved = repository.getByEndpoint(endpoint);
+        if(saved.isPresent() && saved.get().getEndpoint() != null && !saved.get().getEndpoint().isEmpty() &&
+                (ZonedDateTime.now().toEpochSecond() - saved.get().getModified().toEpochSecond()) < cacheSeconds){
+            return JWKSet.parse(saved.get().getKeySet());
+        }else {
+            JWKSet keySet = fetch(new URI(endpoint));
+            if(keySet != null) {
+                JwksDO toSave = saved.orElse(null);
+                ZonedDateTime now = ZonedDateTime.now();
+                if(saved.isEmpty()){
+                    toSave = new JwksDO();
+                    toSave.setEndpoint(endpoint);
+                    toSave.setCreated(now);
+                }
+                toSave.setKeySet(keySet.toString());
+                toSave.setModified(now);
+                repository.save(toSave);
+            }
+            return keySet;
+        }
+    }
+
+    private JWKSet fetch(URI endpoint){
+        try {
+            ResponseEntity<String> response = client.getForEntity(endpoint, String.class);
+            if(response.getStatusCode().is2xxSuccessful()){
+                JWKSet jwkSet = JWKSet.parse(response.getBody());
+                return new JWKSet(jwkSet.getKeys()
+                        .stream()
+                        .filter(jwk -> jwk.getKeyUse().equals(KeyUse.SIGNATURE))
+                        .filter(jwk -> jwk.getKeyType().equals(KeyType.EC) || jwk.getKeyType().equals(KeyType.RSA))
+                        .toList());
+            }
+        } catch (Exception e) {
+            logger.error("Failed to fetch endpoint, skipping.", e);
+        }
+        return null;
+    }
+
+    private JwtDecoder buildDecoder(JWKSet jwkSet){
+        DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+        jwtProcessor.setJWSKeySelector(new JWSVerificationKeySelector<>(
+                jwkSet.getKeys()
+                        .stream()
+                        .map(jwt -> JWSAlgorithm.parse(jwt.getAlgorithm().getName()))
+                        .collect(Collectors.toSet()),
+                new ImmutableJWKSet<>(jwkSet)));
+        NimbusJwtDecoder decoder = new NimbusJwtDecoder(jwtProcessor);
+        List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
+        validators.add(new JwtTimestampValidator());
+        decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(validators));
+        return decoder;
+    }
+}

--- a/src/main/java/com/mytiki/l0_registry/features/latest/sign/SignConfig.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/sign/SignConfig.java
@@ -7,6 +7,7 @@ package com.mytiki.l0_registry.features.latest.sign;
 
 
 import com.mytiki.l0_registry.utilities.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -17,7 +18,7 @@ public class SignConfig {
     public static final String PACKAGE_PATH = Constants.PACKAGE_FEATURES_LATEST_DOT_PATH + ".sign";
 
     @Bean
-    public SignService signService(SignRepository repository){
+    public SignService signService(@Autowired SignRepository repository){
         return new SignService(repository);
     }
 }

--- a/src/test/java/com/mytiki/l0_registry/ConfigTest.java
+++ b/src/test/java/com/mytiki/l0_registry/ConfigTest.java
@@ -46,7 +46,7 @@ public class ConfigTest {
         assertEquals(req.getAppId(), rsp.getAppId());
         assertTrue(rsp.getCreated().isAfter(start));
         assertTrue(rsp.getModified().isAfter(start));
-        assertNull(rsp.getClaims());
+        assertFalse(rsp.getVerifySubject());
         assertNull(rsp.getJwksEndpoint());
     }
 
@@ -59,7 +59,7 @@ public class ConfigTest {
         assertEquals(req.getAppId(), rsp.getAppId());
         assertNotNull(rsp.getModified());
         assertNotNull(rsp.getCreated());
-        assertNull(rsp.getClaims());
+        assertFalse(rsp.getVerifySubject());
         assertNull(rsp.getJwksEndpoint());
     }
 
@@ -77,29 +77,13 @@ public class ConfigTest {
     }
 
     @Test
-    public void Test_Modify_SingleClaim_Success() {
+    public void Test_Modify_VerifySubject_Success() {
         ConfigAOReq req = new ConfigAOReq(UUID.randomUUID().toString(), null, null);
         ConfigAORsp orig = service.modify(req);
         assertNull(orig.getJwksEndpoint());
-
-        List<String> claims = List.of("sub");
-        req.setClaims(claims);
+        req.setVerifySubject(true);
         ConfigAORsp update = service.modify(req);
-        assertEquals(claims, update.getClaims());
-        assertNotEquals(orig.getModified(), update.getModified());
-    }
-
-    @Test
-    public void Test_Modify_MultipleClaims_Success() {
-        ConfigAOReq req = new ConfigAOReq(UUID.randomUUID().toString(), null, null);
-        req.setAppId(UUID.randomUUID().toString());
-        ConfigAORsp orig = service.modify(req);
-        assertNull(orig.getJwksEndpoint());
-
-        List<String> claims = List.of("sub", "aud");
-        req.setClaims(claims);
-        ConfigAORsp update = service.modify(req);
-        assertEquals(claims, update.getClaims());
+        assertEquals(true, update.getVerifySubject());
         assertNotEquals(orig.getModified(), update.getModified());
     }
 }

--- a/src/test/java/com/mytiki/l0_registry/IdTest.java
+++ b/src/test/java/com/mytiki/l0_registry/IdTest.java
@@ -56,7 +56,7 @@ public class IdTest {
         String signHeader = buildSignature(keypair);
 
         IdAORsp rsp = service.get(UUID.randomUUID().toString(), UUID.randomUUID().toString(),
-                new AddressSignature(signHeader));
+                new AddressSignature(signHeader), null);
         assertNull(rsp);
     }
 
@@ -67,7 +67,7 @@ public class IdTest {
         String signHeader = buildSignature(keypair);
 
         IdAOReq req = new IdAOReq(UUID.randomUUID().toString(), address);
-        IdAORsp rsp = service.register(UUID.randomUUID().toString(), req, new AddressSignature(signHeader));
+        IdAORsp rsp = service.register(UUID.randomUUID().toString(), req, new AddressSignature(signHeader), null);
 
         assertNotNull(rsp.getSignKey());
         assertTrue(rsp.getAddresses().contains(address));
@@ -80,8 +80,8 @@ public class IdTest {
         String signHeader = buildSignature(keypair);
 
         IdAOReq req = new IdAOReq(UUID.randomUUID().toString(), address);
-        service.register(UUID.randomUUID().toString(), req, new AddressSignature(signHeader));
-        IdAORsp rsp2 = service.register(UUID.randomUUID().toString(), req, new AddressSignature(signHeader));
+        service.register(UUID.randomUUID().toString(), req, new AddressSignature(signHeader), null);
+        IdAORsp rsp2 = service.register(UUID.randomUUID().toString(), req, new AddressSignature(signHeader), null);
 
         assertTrue(rsp2.getAddresses().contains(address));
         assertEquals(rsp2.getAddresses().size(), 1);
@@ -95,13 +95,13 @@ public class IdTest {
         String address1 = address(keypair.toRSAPublicKey());
         String signHeader = buildSignature(keypair);
         IdAOReq req = new IdAOReq(UUID.randomUUID().toString(), address1);
-        IdAORsp rsp1 = service.register(appId, req, new AddressSignature(signHeader));
+        IdAORsp rsp1 = service.register(appId, req, new AddressSignature(signHeader), null);
 
         keypair = keypair();
         String address2 = address(keypair.toRSAPublicKey());
         signHeader = buildSignature(keypair);
         req.setAddress(address2);
-        IdAORsp rsp2 = service.register(appId, req, new AddressSignature(signHeader));
+        IdAORsp rsp2 = service.register(appId, req, new AddressSignature(signHeader), null);
 
         assertEquals(rsp1.getSignKey(), rsp2.getSignKey());
         assertEquals(rsp2.getAddresses().size(), 2);
@@ -119,8 +119,8 @@ public class IdTest {
         String signHeader = buildSignature(keypair);
 
         IdAOReq req = new IdAOReq(cid, address);
-        IdAORsp registerRsp = service.register(appId, req, new AddressSignature(signHeader));
-        IdAORsp getRsp = service.get(appId, cid, new AddressSignature(signHeader));
+        IdAORsp registerRsp = service.register(appId, req, new AddressSignature(signHeader), null);
+        IdAORsp getRsp = service.get(appId, cid, new AddressSignature(signHeader), null);
 
         assertEquals(registerRsp.getSignKey(), getRsp.getSignKey());
         assertEquals(registerRsp.getAddresses().size(), getRsp.getAddresses().size());
@@ -132,7 +132,7 @@ public class IdTest {
     public void Test_GetBadSig_Failure(){
         ApiException ex = assertThrows(ApiException.class,
                 () ->  service.get(UUID.randomUUID().toString(), UUID.randomUUID().toString(), new AddressSignature(
-                                UUID.randomUUID() + "." + UUID.randomUUID() + "." + UUID.randomUUID())));
+                                UUID.randomUUID() + "." + UUID.randomUUID() + "." + UUID.randomUUID()), null));
         assertEquals(HttpStatus.UNAUTHORIZED, ex.getHttpStatus());
     }
 
@@ -145,13 +145,13 @@ public class IdTest {
         String address = address(keypair.toRSAPublicKey());
         String signHeader = buildSignature(keypair);
         IdAOReq req = new IdAOReq(cid, address);
-        service.register(appId, req, new AddressSignature(signHeader));
+        service.register(appId, req, new AddressSignature(signHeader), null);
 
         ApiException ex = assertThrows(ApiException.class,
                 () -> {
                     RSAKey kp = keypair();
                     String header = buildSignature(kp);
-                    service.get(appId, cid, new AddressSignature(header));
+                    service.get(appId, cid, new AddressSignature(header), null);
                 });
         assertEquals(HttpStatus.UNAUTHORIZED, ex.getHttpStatus());
     }

--- a/src/test/java/com/mytiki/l0_registry/JwksTest.java
+++ b/src/test/java/com/mytiki/l0_registry/JwksTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_registry;
+
+import com.mytiki.l0_registry.features.latest.config.ConfigDO;
+import com.mytiki.l0_registry.features.latest.jwks.JwksDO;
+import com.mytiki.l0_registry.features.latest.jwks.JwksRepository;
+import com.mytiki.l0_registry.features.latest.jwks.JwksService;
+import com.mytiki.l0_registry.main.App;
+import com.mytiki.l0_registry.utilities.Constants;
+import com.mytiki.spring_rest_api.ApiException;
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.CurveBasedJWK;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Date;
+import java.text.ParseException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {App.class}
+)
+@ActiveProfiles(profiles = {"ci", "dev", "local"})
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class JwksTest {
+    @Autowired
+    private JwksRepository repository;
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+    private MockRestServiceServer mockServer;
+    private final String dummyEndpoint = "http://localhost:8080/.well-known/jwks.json";
+    private final String jwksRS256 = """
+            {
+                "keys": [
+                    {
+                        "p": "30DlK7TX5mHgHQhDHqIT8GB3fXwzMz1kHmLldJLixg3MzRliM-BU8HAs-sZ01TkgQD8vMbv6FZzJEuO4CLoCaGlLKfRPjACvjMF2NrlvCIIFUguRgr3BvyK98mRA4g7ChA_K7_HPuL5v24bjyF_zEtUZJ3sy0rEjyRAx8hAXlE0",
+                        "kty": "RSA",
+                        "q": "mpS56bvvvis0zFBOUz3OHQFY_sOcsUHqMgsWYW9kxGWCZenmmGqiC7_7igrh303ev3pVXxiZuOjtMSS6ug_Nk5gfLVh7yvtcLEYqdeATBVSLh8nLLagSO7dJBcJTOXG-HATUG78KdeUXv7Mqim0NvEmD_HRVf9kJ8cZZzO8ysKk",
+                        "d": "OXDcNUGLH6I5ljfFUCDx7LkN8GvZ4TCo75kM0pnHxbhiSTbVClK0bWf5zMox5JdZ4EuB7G9PWFt41QKNbTYrwxhLJDX9q3do6vGePWH_v3kMC77uZq7vg-r47Y35Uy2wmZQk_jT7KLRNt5fsAbgHv9splT70lMILStLCpqOYPVgfWWdBT-woG3SqiXFPaz_iJkEWoB6gKJ3hfKwYo_av07P3Bnrc_kZ9dgYSiyT8MR5hMwzS8g-96mHwNR1XW9C3fy0IiOdWqinngWBS0cQTDDbo-JQTS39RFxD_pgEIi_ejotpQEFrXlk4WHjwp8nwKgsiMKZToPP6LuFrTvXBXYQ",
+                        "e": "AQAB",
+                        "use": "sig",
+                        "kid": "76e77cea-5ee2-478f-a16e-93eb12c1dd45",
+                        "qi": "OJFOfEV5TrcMxlbOD1aH2IXPCiDCaTnt6zdGgVv1Sr1HsZDlQof9U1G5H4oBFpvtFgOMe4mVDpqZatJAzSLcPTRHiCIhCz_pOPqFYJiJ7gzx2ctgCwCtGuIWtbcrgGjATXJ24kjDmvo9gdJx-SbLg269wWQKo3Uh79xj5Az23uQ",
+                        "dp": "uaRc7FsUrJ32ni2gonhj3B5bPh1o9dK2zg2uf6EksUwIYQQahMil2MlunZkozaUTDFl-BP0ql44oJWz2O0txdSEZP2nIO8LWN1Un15mampiDlBXKic0Ars9U45o52cAsP2Rie-O3twekPAeOobAnkCFjKVFokYp7F1ZAMejvsoE",
+                        "alg": "RS256",
+                        "dq": "Iepdu_2jBTtfkzBPbw4RaeXAy-zJNU77_kzWdTxGhJys9oVSNcC3mxJdMxVeJ2tjYumJT5sLJznbyLuBSI9tEGQA-yb9yjRKLeCbMk-efL3m-zz4GiVVEssM93mCXwkop-cbTpckyWchRcsem06AA_6xObOgirNo7iYRz9fvbDk",
+                        "n": "hs69goOhErRoVEeAY4FmBWZADpxmGQzhoXcryh6V_hzqAPIA8hc4ATa7OVLjitoUJY_56Y0X-EB55PNTUgkVrJhraPfUq3oox6cfpVrU-PUh2BzEyL3uqb-Pk1_adfm-7Emn_v3I61dEuiZxyFqpLKT9bX3I0_AfXEnwhRhBgCkMf-JXquV5S7KXR8Dy90yi4rErGeqSgZRtcL1DF63f7lMxmumP5jEc_mu4nZfvNXm8M5Ku-x-cDDSr5B9zqBrEDkqSwl197FQygn80rnkRevJBoaF665rDJRKN6Nn32ZMhdKGQ4ZEpyApfzCHQpdcBcBp-vXXzA7DSO35Hr4_W1Q"
+                    }
+                ]
+            }""";
+    private final String jwksES256 = """
+            {
+                "keys": [
+                    {
+                        "kty": "EC",
+                        "d": "RNA2EmYNa8lRkWovqQ65wyrHE-3vmgGZiX8D7LPBfmg",
+                        "use": "sig",
+                        "crv": "P-256",
+                        "kid": "6373263a-8761-4e07-bed0-ffa0d7783741",
+                        "x": "XN9VmEwJnQKDjnnBP8E6nBoMP-rPIJ28A_YAC-ZK33M",
+                        "y": "v59-3V86_XTFfWBjEgHcKDC7vFBpJXUPOn6GkUiq4Tg",
+                        "alg": "ES256"
+                    }
+                ]
+            }""";
+
+    @BeforeEach
+    public void init() {
+        mockServer = MockRestServiceServer.createServer(testRestTemplate.getRestTemplate());
+    }
+
+    @Test
+    public void Test_NoEnpoint_Success() {
+        JwksService service = new JwksService(repository, testRestTemplate.getRestTemplate(),0);
+        ConfigDO configDO = new ConfigDO();
+        service.guard(UUID.randomUUID().toString(), UUID.randomUUID().toString(), configDO);
+    }
+
+    @Test
+    public void Test_ES256_Success() throws URISyntaxException, ParseException, JOSEException {
+        mockServer.expect(requestTo(new URI(dummyEndpoint)))
+                .andRespond(withStatus(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(jwksES256));
+        JwksService service = new JwksService(repository, testRestTemplate.getRestTemplate(), 0);
+        ConfigDO configDO = new ConfigDO();
+        configDO.setJwksEndpoint(dummyEndpoint);
+        JWSObject jwt = buildJwt(null,
+                signer(jwksES256, "6373263a-8761-4e07-bed0-ffa0d7783741"), JWSAlgorithm.ES256);
+        service.guard(UUID.randomUUID().toString(), jwt.serialize(), configDO);
+    }
+
+    @Test
+    public void Test_RS256_Success() throws URISyntaxException, ParseException, JOSEException {
+        mockServer.expect(requestTo(new URI(dummyEndpoint)))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(jwksRS256));
+        JwksService service = new JwksService(repository, testRestTemplate.getRestTemplate(), 0);
+        ConfigDO configDO = new ConfigDO();
+        configDO.setJwksEndpoint(dummyEndpoint);
+        JWSObject jwt = buildJwt(null,
+                signer(jwksRS256, "76e77cea-5ee2-478f-a16e-93eb12c1dd45"), JWSAlgorithm.RS256);
+        service.guard(UUID.randomUUID().toString(), jwt.serialize(), configDO);
+    }
+
+    @Test
+    public void Test_BadUri_Success() throws URISyntaxException, ParseException, JOSEException {
+        mockServer.expect(requestTo(new URI(dummyEndpoint)))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(""));
+        JwksService service = new JwksService(repository, testRestTemplate.getRestTemplate(), 0);
+        ConfigDO configDO = new ConfigDO();
+        configDO.setJwksEndpoint(dummyEndpoint);
+        JWSObject jwt = buildJwt(null,
+                signer(jwksRS256, "76e77cea-5ee2-478f-a16e-93eb12c1dd45"), JWSAlgorithm.RS256);
+        service.guard(UUID.randomUUID().toString(), jwt.serialize(), configDO);
+    }
+
+    @Test
+    public void Test_Subject_Success() throws URISyntaxException, ParseException, JOSEException {
+        mockServer.expect(requestTo(new URI(dummyEndpoint)))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(jwksRS256));
+        JwksService service = new JwksService(repository, testRestTemplate.getRestTemplate(), 0);
+        ConfigDO configDO = new ConfigDO();
+        configDO.setJwksEndpoint(dummyEndpoint);
+        configDO.setVerifySubject(true);
+        String subject = UUID.randomUUID().toString();
+        JWSObject jwt = buildJwt(subject,
+                signer(jwksRS256, "76e77cea-5ee2-478f-a16e-93eb12c1dd45"), JWSAlgorithm.RS256);
+        service.guard(subject, jwt.serialize(), configDO);
+    }
+
+    @Test
+    public void Test_InvalidSubject_Success() throws URISyntaxException, ParseException, JOSEException {
+        mockServer.expect(requestTo(new URI(dummyEndpoint)))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(jwksRS256));
+        JwksService service = new JwksService(repository, testRestTemplate.getRestTemplate(), 0);
+        ConfigDO configDO = new ConfigDO();
+        configDO.setJwksEndpoint(dummyEndpoint);
+        configDO.setVerifySubject(true);
+        JWSObject jwt = buildJwt(UUID.randomUUID().toString(),
+                signer(jwksRS256, "76e77cea-5ee2-478f-a16e-93eb12c1dd45"), JWSAlgorithm.RS256);
+
+        ApiException ex = assertThrows(ApiException.class,
+                () ->  service.guard(UUID.randomUUID().toString(), jwt.serialize(), configDO));
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getHttpStatus());
+    }
+
+    @Test
+    public void Test_Cache_Success() throws URISyntaxException, ParseException, JOSEException {
+        String unique = UUID.randomUUID().toString();
+        mockServer.expect(ExpectedCount.once(),
+                requestTo(new URI(dummyEndpoint + unique)))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(jwksES256));
+        JwksService service = new JwksService(repository, testRestTemplate.getRestTemplate(), 5);
+        ConfigDO configDO = new ConfigDO();
+        configDO.setJwksEndpoint(dummyEndpoint + unique);
+        JWSObject jwt = buildJwt(null,
+                signer(jwksES256, "6373263a-8761-4e07-bed0-ffa0d7783741"), JWSAlgorithm.ES256);
+        service.guard(UUID.randomUUID().toString(), jwt.serialize(), configDO);
+
+        Optional<JwksDO> cached = repository.getByEndpoint(dummyEndpoint + unique);
+        assertTrue(cached.isPresent());
+        assertEquals(cached.get().getEndpoint(), dummyEndpoint + unique);
+        assertNotNull(cached.get().getCreated());
+        assertNotNull(cached.get().getModified());
+
+        service.guard(UUID.randomUUID().toString(), jwt.serialize(), configDO);
+        Optional<JwksDO> cached2 = repository.getByEndpoint(dummyEndpoint + unique);
+        assertTrue(cached2.isPresent());
+        assertEquals(cached.get().getModified(), cached2.get().getModified());
+    }
+
+    private JWSObject buildJwt(String sub, JWSSigner signer, JWSAlgorithm algorithm) throws JOSEException {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        JWSObject jws = new JWSObject(
+                new JWSHeader
+                        .Builder(algorithm)
+                        .type(JOSEObjectType.JWT)
+                        .build(),
+                new Payload(
+                        new JWTClaimsSet.Builder()
+                                .issuer(Constants.MODULE_DOT_PATH)
+                                .issueTime(java.sql.Date.from(now.toInstant()))
+                                .expirationTime(Date.from(now.plusSeconds(60).toInstant()))
+                                .subject(sub)
+                                .build()
+                                .toJSONObject()
+                ));
+        jws.sign(signer);
+        return jws;
+    }
+
+    private JWSSigner signer(String jwks, String kid) throws ParseException, JOSEException {
+        JWKSet jwkSet = JWKSet.parse(jwks);
+        JWK jwk = jwkSet.getKeyByKeyId(kid);
+
+        if(jwk.getKeyType().equals(KeyType.EC))
+            return new ECDSASigner(jwk.toECKey().toECPrivateKey(), ((CurveBasedJWK) jwk).getCurve());
+        else
+            return new RSASSASigner(jwk.toRSAKey().toRSAPrivateKey());
+    }
+}


### PR DESCRIPTION
closes #6 

Uses the optional X-Customer-Authorization to deliver a second JWT to be validated against the configured endpoint.

_available for both ID API routes_