### PR TITLE
fix: sanitize customerToken

### DIFF
--- a/src/main/java/com/mytiki/l0_registry/features/latest/id/IdController.java
+++ b/src/main/java/com/mytiki/l0_registry/features/latest/id/IdController.java
@@ -36,6 +36,7 @@ public class IdController {
                           @RequestHeader(AddressSignature.HEADER) String addressSignature,
                           @RequestHeader(value = "X-Customer-Authorization", required = false) String customerToken,
                           @RequestBody IdAOReq body) {
+        if(customerToken == null) customerToken = "";
         return service.register(
                 principal.getName(),
                 body,


### PR DESCRIPTION
If `customerToken` is null, set it to an empty string. 